### PR TITLE
Fix missing semicolon in 404 script

### DIFF
--- a/_pages/404.md
+++ b/_pages/404.md
@@ -9,7 +9,7 @@ Sorry, but the page you were trying to view does not exist --- perhaps you can t
 
 <script>
   var GOOG_FIXURL_LANG = 'en';
-  var GOOG_FIXURL_SITE = '{{ site.url }}'
+  var GOOG_FIXURL_SITE = '{{ site.url }}';
 </script>
 <script src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js">
 </script>


### PR DESCRIPTION
## Summary
- add missing semicolon to GOOG_FIXURL_SITE in 404 page script

## Testing
- `bundle exec jekyll build` *(fails: bundler: command not found: jekyll)*

------
https://chatgpt.com/codex/tasks/task_e_6895fede424c832db085c308522b9baf